### PR TITLE
Setups up auto-consul to use aws-sdk-v1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'aws-sdk-v1'
 gem 'aws-sdk'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,20 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (1.40.0)
+    aws-sdk (1.34.1)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
+      uuidtools (~> 2.1)
+    aws-sdk-v1 (1.61.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
     coderay (1.1.0)
     diff-lcs (1.2.5)
-    json (1.8.1)
+    json (1.8.2)
     method_source (0.8.2)
-    mini_portile (0.5.3)
-    nokogiri (1.6.1)
-      mini_portile (~> 0.5.0)
+    mini_portile (0.6.2)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
     pry (0.9.12.6)
       coderay (~> 1.0)
       method_source (~> 0.8)
@@ -25,12 +29,14 @@ GEM
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.6)
     slop (3.5.0)
+    uuidtools (2.1.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   aws-sdk
+  aws-sdk-v1
   pry (~> 0.9.0)
   rake (~> 10.1.0)
   rspec

--- a/auto-consul.gemspec
+++ b/auto-consul.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
   s.files       = FileList['lib/**/*.rb', 'spec/**/*.rb', 'bin/*', '[A-Z]*'].to_a
   s.executables << 'auto-consul'
 
-  s.add_dependency('aws-sdk')
-
+  s.add_dependency('aws-sdk'   , '~> 2')
+  s.add_dependency('aws-sdk-v1', '~> 1')
   s.add_development_dependency('bundler')
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec')

--- a/lib/auto-consul/providers/s3.rb
+++ b/lib/auto-consul/providers/s3.rb
@@ -1,3 +1,4 @@
+require 'aws-sdk-v1'
 require 'aws-sdk'
 
 module AutoConsul::Cluster::Registry


### PR DESCRIPTION
Unit tests all pass.  You should test this further yourself but it should make auto-consul work with the new setup they expect.

As per the directions from:
  http://ruby.awsblog.com/post/TxFKSK2QJE6RPZ/Upcoming-Stable-Release-of-AWS-SDK-for-Ruby-Version-1